### PR TITLE
exposing the private IP variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ No modules.
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | (Optional) The ARN of the policy that is used to set the permissions boundary for the role. | `string` | `null` | no |
 | <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | List of IAM policy ARNs to attach to the instance profile | `list(string)` | `[]` | no |
 | <a name="input_policy_content"></a> [policy\_content](#input\_policy\_content) | JSON IAM Policy body. Use this to add a custom policy to your instance profile (Optional) | `string` | `null` | no |
+| <a name="input_private_ip"></a> [private\_ip](#input\_private\_ip) | The private IP address to assign to the bastion | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_root_volume_config"></a> [root\_volume\_config](#input\_root\_volume\_config) | n/a | <pre>object({<br>    volume_type = any<br>    volume_size = any<br>  })</pre> | <pre>{<br>  "volume_size": "20",<br>  "volume_type": "gp3"<br>}</pre> | no |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | List of security groups to associate with instance | `list(any)` | `[]` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -57,6 +57,7 @@ Example that uses the module with many of its configurations. Used in CI E2E tes
 | <a name="input_iam_role_permissions_boundary"></a> [iam\_role\_permissions\_boundary](#input\_iam\_role\_permissions\_boundary) | ARN of a permissions boundary policy to use when creating IAM roles | `string` | `null` | no |
 | <a name="input_kms_key_deletion_window"></a> [kms\_key\_deletion\_window](#input\_kms\_key\_deletion\_window) | Waiting period for scheduled KMS Key deletion. Can be 7-30 days. | `number` | `7` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | The prefix to use when naming all resources | `string` | n/a | yes |
+| <a name="input_private_ip"></a> [private\_ip](#input\_private\_ip) | The private IP address to assign to the bastion | `string` | `""` | no |
 | <a name="input_region"></a> [region](#input\_region) | The AWS region to deploy into | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to all resources | `map(string)` | `{}` | no |
 | <a name="input_zarf_version"></a> [zarf\_version](#input\_zarf\_version) | The version of Zarf to use | `string` | `""` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -255,8 +255,10 @@ module "bastion" {
   assign_public_ip               = false
   enable_log_to_s3               = true
   enable_log_to_cloudwatch       = true
-  tenancy                        = var.bastion_tenancy
-  zarf_version                   = var.zarf_version
-  permissions_boundary           = var.iam_role_permissions_boundary
-  tags                           = var.tags
+  private_ip                     = var.private_ip != "" ? var.private_ip : null
+
+  tenancy              = var.bastion_tenancy
+  zarf_version         = var.zarf_version
+  permissions_boundary = var.iam_role_permissions_boundary
+  tags                 = var.tags
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -71,3 +71,9 @@ variable "enable_sqs_events_on_access_log_access" {
   type        = bool
   default     = false
 }
+
+variable "private_ip" {
+  description = "The private IP address to assign to the bastion"
+  type        = string
+  default     = ""
+}

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,7 @@ resource "aws_instance" "application" {
   associate_public_ip_address = var.assign_public_ip
   monitoring                  = true
   tenancy                     = var.tenancy
+  private_ip                  = var.private_ip
   root_block_device {
     volume_size = var.root_volume_config.volume_size
     volume_type = var.root_volume_config.volume_type

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,12 @@ variable "allowed_public_ips" {
   default     = []
 }
 
+variable "private_ip" {
+  type        = string
+  description = "The private IP address to assign to the bastion"
+  default     = null
+}
+
 variable "ami_name_filter" {
   type        = string
   description = "Filter for AMI using this name. Accepts wildcards"


### PR DESCRIPTION
This PR allows the Private IP variable to be exposed at the level main.tf. It fulfills the request in issue #15.