### PR TITLE
Fix typo in workflow docker cache

### DIFF
--- a/.github/actions/init-pipeline/action.yml
+++ b/.github/actions/init-pipeline/action.yml
@@ -22,7 +22,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: "${{ github.workspace }}/.cache/docker"
-        key: "docker|${{ hashFiles('Makefile') }}"
+        key: "docker|${{ hashFiles('.env') }}"
 
     - name: Docker save build harness
       if: steps.init-docker-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
The version of Build Harness isn't specified in the Makefile anymore, it is in the .env file.