### PR TITLE
userdata updates

### DIFF
--- a/templates/user_data.sh.tpl
+++ b/templates/user_data.sh.tpl
@@ -30,7 +30,7 @@ fi
 # Install needed tools
 # TODO: Make this work in more AMIs than just Amazon Linux 2 (for example, on RHEL the amazon-cloudwatch-agent package doesn't exist)
 sudo yum install -y \
-  amazon-cloudwatch-agent
+  amazon-cloudwatch-agent \
   docker \
   git \
   jq \

--- a/templates/user_data.sh.tpl
+++ b/templates/user_data.sh.tpl
@@ -80,7 +80,7 @@ sudo cat << '_EOF_' > /etc/profile.d/startupscript.sh
     {
         ###Configuration Options
         MAX_SESSIONS=1  #Number of maximum sessions allowed
-        TERMINATE_SESSIONS=false #This will terminate the sessions starting from the oldest; if set to false, it will list out the sessions IDs, but not terminate them
+        TERMINATE_SESSIONS=true #This will terminate the sessions starting from the oldest; if set to false, it will list out the sessions IDs, but not terminate them
         TERMINATE_OLDEST=false #true/false - if true, script will terminate the oldest session first. if false, the newest session will be terminated.
         #Terminating the newest session may result in poor experiance as there will be no message provided to the user.
 


### PR DESCRIPTION
The Userdata script previously had a missing `\` in the yum install command:
 ```
sudo yum install -y \
  amazon-cloudwatch-agent
  docker \
  git \
  jq \
  unzip \
  wget
```
This caused issues with other parts of the script due to not all of the utilities being installed. Also changing the default behavior of the startup script. Previously it notified users that someone else had logged into the instance. With this change it will terminate the newest session, only allowing one user at a time.